### PR TITLE
feat: prefer git upstream when it exists

### DIFF
--- a/lua/open-handlers/init.lua
+++ b/lua/open-handlers/init.lua
@@ -19,10 +19,13 @@ end
 
 ---@return nil|string
 local function get_git_origin()
-	local res = vim.system({ "git", "config", "--get", "remote.origin.url" }, { text = true }):wait()
+	local res = vim.system({ "git", "config", "--get", "remote.upstream.url" }, { text = true }):wait()
 
 	if res.code ~= 0 then
-		return nil
+		res = vim.system({ "git", "config", "--get", "remote.origin.url" }, { text = true }):wait()
+		if res.code ~= 0 then
+			return nil
+		end
 	end
 
 	return ssh_to_http(res.stdout)


### PR DESCRIPTION
I noticed that issues are opened on my fork of the repo instead of upstream, which is never what I want. So this PR was born.

I could make the list of remotes configurable if you would prefer that, just lmk
